### PR TITLE
Add preset row override

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,23 +53,33 @@ You do it by declaring the rows as arrays and its buttons as values, like this:
 rows:
   power_row:
     - power
-  media_control_row:
-    - rewind
-    - play
-    - pause
-    - fast_forward
+  media_control_row: true
   volume_row: slider
   numpad_row: true
   navigation_row: touchpad
 ```
 
-The preset rows are `volume_row`, `numpad_row` and `navigation_row`, which requires a string or boolean as value.
+The preset rows are `volume_row`, `numpad_row`, `navigation_row`, and `media_control_row`, which can optionally be set as string or boolean values:
 
 | Name | Type | Description
 | ---- | ---- | -------
 | volume_row | string | Can be either `slider` or `buttons`. This defines the mode you want for setting the volume (you'll see them soon below). You need to have [slider-card](https://github.com/AnthonMS/my-cards) installed in order to use `slider`.
 | numpad_row | boolean | If `true`, numpad row will show.
 | navigation_row | string | Can be either `touchpad` or `buttons`. This defines the mode you want for navigating around your tv (you'll also see them soon below).
+| media_control_row | boolean | If `true`, media control row will show.
+
+Preset rows can also be overridden by declaring them as arrays.
+The following example is equivalent to `media_control_row: true`:
+
+```yaml
+rows:
+  ...
+  media_control_row:
+    - rewind
+    - play
+    - pause
+    - fast_forward
+```
 
 ## **Notice**
 
@@ -336,7 +346,7 @@ Result:
 
 ### Extra
 
-In any row, if you add an ampty item, there will be an empty/invisible button filling the space:
+In any row, if you add an empty item, there will be an empty/invisible button filling the space:
 
 ```yaml
 rows:

--- a/tv-card.js
+++ b/tv-card.js
@@ -574,4 +574,4 @@ class TVCardServices extends LitElement {
     }
 }
 
-customElements.define("tv-remote-card", TVCardServices);
+customElements.define("tv-card", TVCardServices);

--- a/tv-card.js
+++ b/tv-card.js
@@ -446,84 +446,84 @@ class TVCardServices extends LitElement {
 
         var content = [];
         Object.keys(this.rows).forEach((row_name) => {
-			let row_actions = this.rows[row_name];
+            let row_actions = this.rows[row_name];
 
-			if (preset_rows.includes(row_name)) {
-				if (row_name === "volume_row") {
-					let volume_row = [];
-					if (this.rows.volume_row == "buttons") {
-						volume_row = [
-							this.buildIconButton("volume_down"),
-							this.buildIconButton("volume_mute"),
-							this.buildIconButton("volume_up"),
-						];
-					} else if (this.rows.volume_row == "slider") {
-						volume_row = [this.volume_slider];
-					}
-					content.push(volume_row);
-				} else if (row_name === "navigation_row") {
-					let navigation_row = [];
+            if (preset_rows.includes(row_name)) {
+                if (row_name === "volume_row") {
+                    let volume_row = [];
+                    if (this.rows.volume_row == "buttons") {
+                        volume_row = [
+                            this.buildIconButton("volume_down"),
+                            this.buildIconButton("volume_mute"),
+                            this.buildIconButton("volume_up"),
+                        ];
+                    } else if (this.rows.volume_row == "slider") {
+                        volume_row = [this.volume_slider];
+                    }
+                    content.push(volume_row);
+                } else if (row_name === "navigation_row") {
+                    let navigation_row = [];
 
-					if (this.rows.navigation_row == "buttons") {
-						let up_row = [this.buildIconButton("up")];
-						let middle_row = [
-							this.buildIconButton("left"),
-							this.buildIconButton("enter"),
-							this.buildIconButton("right"),
-						];
-						let down_row = [this.buildIconButton("down")];
-						navigation_row = [up_row, middle_row, down_row];
-					} else if (this.rows.navigation_row == "touchpad") {
-						var touchpad = [
-							html`
-								<toucharea
-									id="toucharea"
-									@click="${this.onClick}"
-									@dblclick="${this.onDoubleClick}"
-									@touchstart="${this.onTouchStart}"
-									@touchmove="${this.onTouchMove}"
-									@touchend="${this.onTouchEnd}"
-								>
-								</toucharea>
-							`,
-						];
-						navigation_row = [touchpad];
-					}
-					content.push(...navigation_row);
-				} else if (row_name === "numpad_row") {
-					if (this.rows.numpad_row == true) {
-						let numpad_row = [
-							[
-								this.buildIconButton("num_1"),
-								this.buildIconButton("num_2"),
-								this.buildIconButton("num_3"),
-							],
-							[
-								this.buildIconButton("num_4"),
-								this.buildIconButton("num_5"),
-								this.buildIconButton("num_6"),
-							],
-							[
-								this.buildIconButton("num_7"),
-								this.buildIconButton("num_8"),
-								this.buildIconButton("num_9"),
-							],
-							[
-								this.buildIconButton("channel_down"),
-								this.buildIconButton("num_0"),
-								this.buildIconButton("channel_up"),
-							],
-						];
-						content.push(...numpad_row);
-					}
-				}
-			} else {
-				if (!!row_actions) {
-					let row_content = this.buildButtonsFromActions(row_actions);
-					content.push(row_content);
-				}
-			}
-		});
+                    if (this.rows.navigation_row == "buttons") {
+                        let up_row = [this.buildIconButton("up")];
+                        let middle_row = [
+                            this.buildIconButton("left"),
+                            this.buildIconButton("enter"),
+                            this.buildIconButton("right"),
+                        ];
+                        let down_row = [this.buildIconButton("down")];
+                        navigation_row = [up_row, middle_row, down_row];
+                    } else if (this.rows.navigation_row == "touchpad") {
+                        var touchpad = [
+                            html`
+                            <toucharea
+                            id="toucharea"
+                            @click="${this.onClick}"
+                            @dblclick="${this.onDoubleClick}"
+                            @touchstart="${this.onTouchStart}"
+                            @touchmove="${this.onTouchMove}"
+                            @touchend="${this.onTouchEnd}"
+                            >
+                            </toucharea>
+                            `,
+                        ];
+                        navigation_row = [touchpad];
+                    }
+                    content.push(...navigation_row);
+                } else if (row_name === "numpad_row") {
+                    if (this.rows.numpad_row == true) {
+                        let numpad_row = [
+                            [
+                                this.buildIconButton("num_1"),
+                                this.buildIconButton("num_2"),
+                                this.buildIconButton("num_3"),
+                            ],
+                            [
+                                this.buildIconButton("num_4"),
+                                this.buildIconButton("num_5"),
+                                this.buildIconButton("num_6"),
+                            ],
+                            [
+                                this.buildIconButton("num_7"),
+                                this.buildIconButton("num_8"),
+                                this.buildIconButton("num_9"),
+                            ],
+                            [
+                                this.buildIconButton("channel_down"),
+                                this.buildIconButton("num_0"),
+                                this.buildIconButton("channel_up"),
+                            ],
+                        ];
+                        content.push(...numpad_row);
+                    }
+                }
+            } else {
+                if (!!row_actions) {
+                    let row_content = this.buildButtonsFromActions(row_actions);
+                    content.push(row_content);
+                }
+            }
+        });
 
         content = content.map(this.buildRow);
 

--- a/tv-card.js
+++ b/tv-card.js
@@ -483,14 +483,10 @@ class TVCardServices extends LitElement {
         if (!this._config || !this._hass || !this.volume_slider) {
             return html ``;
         }
-
         const content = Object.keys(this.rows).reduce((acc, rowName) => {
-            if (Object.keys(this.presetRenderFunctions).includes(rowName)) {
-                return [...acc, ...(this.presetRenderFunctions[rowName]() || this.overrideRow(rowName))];
-            } else {
-                return [...acc, this.rows[rowName].map(this.buildIconButton, this)];
-            }
-        }, []).map(rowContents => html `<div class="row">${rowContents}</div>`);
+            const rowArray = this.presetRenderFunctions[rowName]?.() || this.overrideRow(rowName);
+            return [...acc, ...rowArray];
+        }, []).map(rowContents => html`<div class="row">${rowContents}</div>`);
 
         return html `
             ${this.renderStyle()}

--- a/tv-remote-card.js
+++ b/tv-remote-card.js
@@ -466,6 +466,11 @@ class TVCardServices extends LitElement {
                 ["channel_down", "num_0", "channel_up"],
             ].map(row => row.map(this.buildIconButton, this));
         },
+        media_control_row: () => {
+            return [
+                ["rewind", "play", "pause", "fast_forward"].filter(key => Object.keys(this.keys).includes(key))
+            ].map(row => row.map(this.buildIconButton, this));
+        },
     }
     
     render() {

--- a/tv-remote-card.js
+++ b/tv-remote-card.js
@@ -260,7 +260,7 @@ class TVCardServices extends LitElement {
         }, true);
 
         this.volume_slider.hass = this._hass;
-        this.triggerRender();
+        this.trigger = Math.random();
     }
 
     sendKey(key) {
@@ -421,20 +421,51 @@ class TVCardServices extends LitElement {
             </ha-icon-button>
         `;
     }
-    
-    buildRow(content) {
-        return html `
-            <div class="row">
-                ${content}
-            </div>
-        `;
-    }
-    buildButtonsFromActions(actions) {
-        return actions.map((action) => this.buildIconButton(action));
-    }
 
-    triggerRender() {
-        this.trigger = Math.random();
+    presetRenderFunctions = {
+        volume_row: () => {
+            if (this.rows.volume_row == "buttons") {
+                return [
+                    ["volume_down", "volume_mute", "volume_up"]
+                ].map(row => row.map(this.buildIconButton, this));
+            } else if (this.rows.volume_row == "slider") {
+                return [[this.volume_slider]];
+            }
+            return [[]]
+        },
+        navigation_row: () => {
+            if (this.rows.navigation_row == "buttons") {
+                return [
+                    ["up"],
+                    ["left", "enter", "right"],
+                    ["down"],
+                ].map(row => row.map(this.buildIconButton, this));
+            } else if (this.rows.navigation_row == "touchpad") {
+                return [[html`
+                    <toucharea
+                        id="toucharea"
+                        @click="${this.onClick}"
+                        @dblclick="${this.onDoubleClick}"
+                        @touchstart="${this.onTouchStart}"
+                        @touchmove="${this.onTouchMove}"
+                        @touchend="${this.onTouchEnd}"
+                    >
+                    </toucharea>
+                `]];
+            }
+            return [[]]
+        },
+        numpad_row: () => {
+            if (!this.rows.numpad_row) {
+                return [[]]
+            }
+            return [
+                ["num_1", "num_2", "num_3"],
+                ["num_4", "num_5", "num_6"],
+                ["num_7", "num_8", "num_9"],
+                ["channel_down", "num_0", "channel_up"],
+            ].map(row => row.map(this.buildIconButton, this));
+        },
     }
     
     render() {
@@ -442,97 +473,18 @@ class TVCardServices extends LitElement {
             return html ``;
         }
 
-        const preset_rows = ["navigation_row","numpad_row","volume_row"]
-
-        var content = [];
-        Object.keys(this.rows).forEach((row_name) => {
-            let row_actions = this.rows[row_name];
-
-            if (preset_rows.includes(row_name)) {
-                if (row_name === "volume_row") {
-                    let volume_row = [];
-                    if (this.rows.volume_row == "buttons") {
-                        volume_row = [
-                            this.buildIconButton("volume_down"),
-                            this.buildIconButton("volume_mute"),
-                            this.buildIconButton("volume_up"),
-                        ];
-                    } else if (this.rows.volume_row == "slider") {
-                        volume_row = [this.volume_slider];
-                    }
-                    content.push(volume_row);
-                } else if (row_name === "navigation_row") {
-                    let navigation_row = [];
-
-                    if (this.rows.navigation_row == "buttons") {
-                        let up_row = [this.buildIconButton("up")];
-                        let middle_row = [
-                            this.buildIconButton("left"),
-                            this.buildIconButton("enter"),
-                            this.buildIconButton("right"),
-                        ];
-                        let down_row = [this.buildIconButton("down")];
-                        navigation_row = [up_row, middle_row, down_row];
-                    } else if (this.rows.navigation_row == "touchpad") {
-                        var touchpad = [
-                            html`
-                            <toucharea
-                            id="toucharea"
-                            @click="${this.onClick}"
-                            @dblclick="${this.onDoubleClick}"
-                            @touchstart="${this.onTouchStart}"
-                            @touchmove="${this.onTouchMove}"
-                            @touchend="${this.onTouchEnd}"
-                            >
-                            </toucharea>
-                            `,
-                        ];
-                        navigation_row = [touchpad];
-                    }
-                    content.push(...navigation_row);
-                } else if (row_name === "numpad_row") {
-                    if (this.rows.numpad_row == true) {
-                        let numpad_row = [
-                            [
-                                this.buildIconButton("num_1"),
-                                this.buildIconButton("num_2"),
-                                this.buildIconButton("num_3"),
-                            ],
-                            [
-                                this.buildIconButton("num_4"),
-                                this.buildIconButton("num_5"),
-                                this.buildIconButton("num_6"),
-                            ],
-                            [
-                                this.buildIconButton("num_7"),
-                                this.buildIconButton("num_8"),
-                                this.buildIconButton("num_9"),
-                            ],
-                            [
-                                this.buildIconButton("channel_down"),
-                                this.buildIconButton("num_0"),
-                                this.buildIconButton("channel_up"),
-                            ],
-                        ];
-                        content.push(...numpad_row);
-                    }
-                }
+        const content = Object.keys(this.rows).reduce((acc, rowName) => {
+            if (Object.keys(this.presetRenderFunctions).includes(rowName)) {
+                return [...acc, ...this.presetRenderFunctions[rowName]()];
             } else {
-                if (!!row_actions) {
-                    let row_content = this.buildButtonsFromActions(row_actions);
-                    content.push(row_content);
-                }
+                return [...acc, this.rows[rowName].map(this.buildIconButton, this)];
             }
-        });
+        }, []).map(rowContents => html `<div class="row">${rowContents}</div>`);
 
-        content = content.map(this.buildRow);
-
-        var output = html `
+        return html `
             ${this.renderStyle()}
             <ha-card .header="${this._config.title}">${content}</ha-card>
         `;
-
-        return html `${output}`;
     }
 
     renderStyle() {
@@ -611,4 +563,4 @@ class TVCardServices extends LitElement {
     }
 }
 
-customElements.define("tv-card", TVCardServices);
+customElements.define("tv-card-b", TVCardServices);

--- a/tv-remote-card.js
+++ b/tv-remote-card.js
@@ -431,7 +431,6 @@ class TVCardServices extends LitElement {
             } else if (this.rows.volume_row == "slider") {
                 return [[this.volume_slider]];
             }
-            return [[]]
         },
         navigation_row: () => {
             if (this.rows.navigation_row == "buttons") {
@@ -453,26 +452,33 @@ class TVCardServices extends LitElement {
                     </toucharea>
                 `]];
             }
-            return [[]]
         },
         numpad_row: () => {
-            if (!this.rows.numpad_row) {
-                return [[]]
+            if (this.rows.numpad_row === true) {
+                return [
+                    ["num_1", "num_2", "num_3"],
+                    ["num_4", "num_5", "num_6"],
+                    ["num_7", "num_8", "num_9"],
+                    ["channel_down", "num_0", "channel_up"],
+                ].map(row => row.map(this.buildIconButton, this));
             }
-            return [
-                ["num_1", "num_2", "num_3"],
-                ["num_4", "num_5", "num_6"],
-                ["num_7", "num_8", "num_9"],
-                ["channel_down", "num_0", "channel_up"],
-            ].map(row => row.map(this.buildIconButton, this));
         },
         media_control_row: () => {
-            return [
-                ["rewind", "play", "pause", "fast_forward"].filter(key => Object.keys(this.keys).includes(key))
-            ].map(row => row.map(this.buildIconButton, this));
+            if (this.rows.media_control_row === true) {
+                return [
+                    ["rewind", "play", "pause", "fast_forward"].filter(key => Object.keys(this.keys).includes(key))
+                ].map(row => row.map(this.buildIconButton, this));
+            }
         },
     }
     
+    overrideRow(rowName) {
+        if (this.rows[rowName] instanceof Array) {
+            return [this.rows[rowName].map(this.buildIconButton, this)]
+        }
+        return [[]]
+    }
+
     render() {
         if (!this._config || !this._hass || !this.volume_slider) {
             return html ``;
@@ -480,7 +486,7 @@ class TVCardServices extends LitElement {
 
         const content = Object.keys(this.rows).reduce((acc, rowName) => {
             if (Object.keys(this.presetRenderFunctions).includes(rowName)) {
-                return [...acc, ...this.presetRenderFunctions[rowName]()];
+                return [...acc, ...(this.presetRenderFunctions[rowName]() || this.overrideRow(rowName))];
             } else {
                 return [...acc, this.rows[rowName].map(this.buildIconButton, this)];
             }

--- a/tv-remote-card.js
+++ b/tv-remote-card.js
@@ -568,4 +568,4 @@ class TVCardServices extends LitElement {
     }
 }
 
-customElements.define("tv-card-b", TVCardServices);
+customElements.define("tv-remote-card", TVCardServices);


### PR DESCRIPTION
## New Features
* Preset rows can now be overridden with array values
* `media_control_row` now has a preset value

## Structural Changes
* Preset rendering logic now exists inside of a new class member: `presetRenderFunctions`
  * This member is a dictionary of functions, indexed by row name
* `render` function now uses an array `reduce` function instead of a `forEach`
* `buildRow`, `buildButtonsFromActions`, and `triggerRender` have been refactored into the new implementation